### PR TITLE
Hapi 17+ Compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,127 +34,147 @@ The following sample server shows all features at once:
 ```js
 const Boom          = require("boom")
 const HAPI          = require("hapi")
-const HAPIWebSocket = require("hapi-plugin-websocket")
+const HAPIWebSocket = require("./hapi-plugin-websocket")
 const HAPIAuthBasic = require("hapi-auth-basic")
 
-let server = new HAPI.Server()
-server.connection({ address: "127.0.0.1", port: 12345 })
+async function runServer() {
+    const server = new HAPI.Server({ address: "127.0.0.1", port: 12345 });
 
-server.register(HAPIWebSocket)
-server.register(HAPIAuthBasic)
+    await server.register([
+        HAPIWebSocket, 
+        HAPIAuthBasic
+    ]);
 
-server.auth.strategy("basic", "basic", {
-    validateFunc: (request, username, password, callback) => {
-        if (username === "foo" && password === "bar")
-            callback(null, true, { username: username })
-        else
-            callback(Boom.unauthorized("invalid username/password"), false)
-    }
-})
+    server.auth.strategy('basic', 'basic', {
+        validate: async (request, username, password, h) => {
+            let isValid = false;
+            let credentials = null;
+            if (username === "foo" && password === "bar"){
+                isValid = true;
+                credentials = {id: username, name:username};
+            }
+            return {isValid, credentials};                
+        }
+    });
 
-/*  plain REST route  */
-server.route({
-    method: "POST", path: "/foo",
-    config: {
-        payload: { output: "data", parse: true, allow: "application/json" }
-    },
-    handler: (request, reply) => {
-        reply({ at: "foo", seen: request.payload })
-    }
-})
+    /*  plain REST route  */
+    server.route({
+        method: "POST", path: "/foo",
+        config: {
+            payload: { output: "data", parse: true, allow: "application/json" }
+        },
+        handler: (request, h) => {
+            return { at: "foo", seen: request.payload };
+        }
+    })
 
-/*  combined REST/WebSocket route  */
-server.route({
-    method: "POST", path: "/bar",
-    config: {
-        payload: { output: "data", parse: true, allow: "application/json" },
-        plugins: { websocket: true }
-    },
-    handler: (request, reply) => {
-        let { mode } = request.websocket()
-        reply({ at: "bar", mode: mode, seen: request.payload })
-    }
-})
+    /*  combined REST/WebSocket route  */
+    server.route({
+        method: "POST", path: "/bar",
+        config: {
+            payload: { output: "data", parse: true, allow: "application/json" },
+            plugins: { websocket: true }
+        },
+        handler: (request, h) => {
+            let { mode } = request.websocket()
+            return { at: "bar", mode: mode, seen: request.payload };
+        }
+    })
 
-/*  exclusive WebSocket route  */
-server.route({
-    method: "POST", path: "/baz",
-    config: {
-        plugins: { websocket: { only: true, autoping: 30 * 1000 } }
-    },
-    handler: (request, reply) => {
-        reply({ at: "baz", seen: request.payload })
-    }
-})
+    /*  exclusive WebSocket route  */
+    server.route({
+        method: "POST", path: "/baz",
+        config: {
+            plugins: { websocket: { only: true, autoping: 30 * 1000 } }
+        },
+        handler: (request, h) => {
+            return { at: "baz", seen: request.payload };
+        }
+    })
 
-/*  full-featured exclusive WebSocket route  */
-server.route({
-    method: "POST", path: "/quux",
-    config: {
-        payload: { output: "data", parse: true, allow: "application/json" },
-        auth: { mode: "required", strategy: "basic" },
-        plugins: {
-            websocket: {
-                only: true,
-                initially: true,
-                subprotocol: "quux/1.0",
-                connect: ({ ctx, ws }) => {
-                    ctx.to = setInterval(() => {
-                        ws.send(JSON.stringify({ cmd: "PING" }))
-                    }, 5000)
-                },
-                disconnect: ({ ctx }) => {
-                    if (ctx.to !== null) {
-                        clearTimeout(ctx.to)
-                        ctx.to = null
+    /*  full-featured exclusive WebSocket route  */
+    server.route({
+        method: "POST", path: "/quux",
+        config: {
+            response: {
+              emptyStatusCode: 204
+            },
+            payload: { output: "data", parse: true, allow: "application/json" },
+            auth: { mode: "required", strategy: "basic" },
+            plugins: {
+                websocket: {
+                    only: true,
+                    initially: true,
+                    subprotocol: "quux/1.0",
+                    connect: ({ ctx, ws }) => {
+                        // NOTE: This will crash if the client disconnects
+                        ctx.to = setInterval(() => {
+                            ws.send(JSON.stringify({ cmd: "PING" }))
+                        }, 5000)
+                    },
+                    disconnect: ({ ctx }) => {
+                        if (ctx.to !== null) {
+                            clearTimeout(this.ctx)
+                            ctx.to = null
+                        }
                     }
                 }
             }
-        }
-    },
-    handler: (request, reply) => {
-        let { initially, ws } = request.websocket()
-        if (initially) {
-            ws.send(JSON.stringify({ cmd: "HELLO", arg: request.auth.credentials.username }))
-            return reply().code(204)
-        }
-        if (typeof request.payload.cmd !== "string")
-            return reply(Boom.badRequest("invalid request"))
-        if (request.payload.cmd === "PING")
-            return reply({ result: "PONG" })
-        else if (request.payload.cmd === "AWAKE-ALL") {
-            var peers = request.websocket().peers
-            peers.forEach((peer) => {
-                peer.send(JSON.stringify({ cmd: "AWAKE" }))
-            })
-            return reply().code(204)
-        }
-        else
-            return reply(Boom.badRequest("unknown command"))
-    }
-})
-
-/*  exclusive framed WebSocket route  */
-server.route({
-    method: "POST", path: "/framed",
-    config: {
-        plugins: {
-            websocket: {
-                only:          true,
-                autoping:      30 * 1000,
-                frame:         true,
-                frameEncoding: "json",
-                frameRequest:  "REQUEST",
-                frameResponse: "RESPONSE"
+        },
+        handler: (request, h) => {
+            let { initially, ws } = request.websocket()
+            if (initially) {
+                ws.send(JSON.stringify({ cmd: "HELLO", arg: request.auth.credentials.username }))
+                return ""
+            }
+            if (typeof request.payload.cmd !== "string"){
+                return Boom.badRequest("invalid request");
+            }
+            if (request.payload.cmd === "PING"){
+                return { result: "PONG" }
+            }
+            else if (request.payload.cmd === "AWAKE-ALL") {
+                var peers = request.websocket().peers
+                peers.forEach((peer) => {
+                    peer.send(JSON.stringify({ cmd: "AWAKE" }))
+                })
+                return ""            
+            }
+            else{
+                return Boom.badRequest("unknown command");
             }
         }
-    },
-    handler: (request, reply) => {
-        reply({ at: "framed", seen: request.payload })
-    }
-})
+    })
 
-server.start()
+    /*  exclusive framed WebSocket route  */
+    server.route({
+        method: "POST", path: "/framed",
+        config: {
+            plugins: {
+                websocket: {
+                    only:          true,
+                    autoping:      30 * 1000,
+                    frame:         true,
+                    frameEncoding: "json",
+                    frameRequest:  "REQUEST",
+                    frameResponse: "RESPONSE"
+                }
+            }
+        },
+        handler: (request, h) => {
+            return { at: "framed", seen: request.payload };
+        }
+    })
+
+    try {
+        await server.start();
+    }
+    catch (e){
+        console.log(e);
+    }
+}
+runServer();
+
 ```
 
 You can test-drive this the following way (with the help
@@ -222,13 +242,13 @@ const HAPIWebSocket = require("hapi-plugin-websocket")
 - **Register Module in HAPI** (simple variant):
 
 ```js
-server.register(HAPIWebSocket)
+await server.register(HAPIWebSocket)
 ```
 
 - **Register Module in HAPI** (complex variant):
 
 ```js
-server.register({
+await server.register({
     register: HAPIWebSocket,
     options: {
         create: (wss) => {
@@ -247,8 +267,8 @@ server.route({
     config: {
         plugins: { websocket: true }
     },
-    handler: (request, reply) => {
-        reply(...)
+    handler: (request, h) => {
+        return (...)
     }
 })
 ```
@@ -277,10 +297,10 @@ server.route({
             }
         }
     },
-    handler: (request, reply) => {
+    handler: (request, h) => {
         let { mode, ctx, wss, ws, req, peers, initially } = request.websocket()
         ...
-        reply(...)
+        return (...)
     }
 })
 ```
@@ -302,10 +322,10 @@ server.route({
             }
         }
     },
-    handler: (request, reply) => {
+    handler: (request, h) => {
         let { mode, ctx, wss, ws, wsf, req, peers, initially } = request.websocket()
         ...
-        reply(...)
+        return (...)
     }
 })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,2142 @@
+{
+    "name": "hapi-plugin-websocket",
+    "version": "2.0.0",
+    "lockfileVersion": 1,
+    "requires": true,
+    "dependencies": {
+        "@babel/code-frame": {
+            "version": "7.0.0-beta.31",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0-beta.31.tgz",
+            "integrity": "sha512-yd7CkUughvHQoEahQqcMdrZw6o/6PwUxiRkfZuVDVHCDe77mysD/suoNyk5mK6phTnRW1kyIbPHyCJgxw++LXg==",
+            "dev": true,
+            "requires": {
+                "chalk": "2.3.2",
+                "esutils": "2.0.2",
+                "js-tokens": "3.0.2"
+            }
+        },
+        "@babel/helper-function-name": {
+            "version": "7.0.0-beta.31",
+            "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.31.tgz",
+            "integrity": "sha512-c+DAyp8LMm2nzSs2uXEuxp4LYGSUYEyHtU3fU57avFChjsnTmmpWmXj2dv0yUxHTEydgVAv5fIzA+4KJwoqWDA==",
+            "dev": true,
+            "requires": {
+                "@babel/helper-get-function-arity": "7.0.0-beta.31",
+                "@babel/template": "7.0.0-beta.31",
+                "@babel/traverse": "7.0.0-beta.31",
+                "@babel/types": "7.0.0-beta.31"
+            }
+        },
+        "@babel/helper-get-function-arity": {
+            "version": "7.0.0-beta.31",
+            "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.31.tgz",
+            "integrity": "sha512-m7rVVX/dMLbbB9NCzKYRrrFb0qZxgpmQ4Wv6y7zEsB6skoJHRuXVeb/hAFze79vXBbuD63ci7AVHXzAdZSk9KQ==",
+            "dev": true,
+            "requires": {
+                "@babel/types": "7.0.0-beta.31"
+            }
+        },
+        "@babel/template": {
+            "version": "7.0.0-beta.31",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.0.0-beta.31.tgz",
+            "integrity": "sha512-97IRmLvoDhIDSQkqklVt3UCxJsv0LUEVb/0DzXWtc8Lgiyxj567qZkmTG9aR21CmcJVVIvq2Y/moZj4oEpl5AA==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "7.0.0-beta.31",
+                "@babel/types": "7.0.0-beta.31",
+                "babylon": "7.0.0-beta.31",
+                "lodash": "4.17.5"
+            }
+        },
+        "@babel/traverse": {
+            "version": "7.0.0-beta.31",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.0.0-beta.31.tgz",
+            "integrity": "sha512-3N+VJW+KlezEjFBG7WSYeMyC5kIqVLPb/PGSzCDPFcJrnArluD1GIl7Y3xC7cjKiTq2/JohaLWHVPjJWHlo9Gg==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "7.0.0-beta.31",
+                "@babel/helper-function-name": "7.0.0-beta.31",
+                "@babel/types": "7.0.0-beta.31",
+                "babylon": "7.0.0-beta.31",
+                "debug": "3.1.0",
+                "globals": "10.4.0",
+                "invariant": "2.2.4",
+                "lodash": "4.17.5"
+            }
+        },
+        "@babel/types": {
+            "version": "7.0.0-beta.31",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.0.0-beta.31.tgz",
+            "integrity": "sha512-exAHB+NeFGxkfQ5dSUD03xl3zYGneeSk2Mw2ldTt/nTvYxuDiuSp3DlxgUBgzbdTFG4fbwPk0WtKWOoTXCmNGg==",
+            "dev": true,
+            "requires": {
+                "esutils": "2.0.2",
+                "lodash": "4.17.5",
+                "to-fast-properties": "2.0.0"
+            }
+        },
+        "accept": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/accept/-/accept-3.0.2.tgz",
+            "integrity": "sha512-bghLXFkCOsC1Y2TZ51etWfKDs6q249SAoHTZVfzWWdlZxoij+mgkj9AmUJWQpDY48TfnrTDIe43Xem4zdMe7mQ==",
+            "dev": true,
+            "requires": {
+                "boom": "7.1.1",
+                "hoek": "5.0.3"
+            }
+        },
+        "acorn": {
+            "version": "5.5.3",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
+            "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
+            "dev": true
+        },
+        "acorn-jsx": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+            "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+            "dev": true,
+            "requires": {
+                "acorn": "3.3.0"
+            },
+            "dependencies": {
+                "acorn": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+                    "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+                    "dev": true
+                }
+            }
+        },
+        "ajv": {
+            "version": "5.5.2",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+            "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+            "dev": true,
+            "requires": {
+                "co": "4.6.0",
+                "fast-deep-equal": "1.1.0",
+                "fast-json-stable-stringify": "2.0.0",
+                "json-schema-traverse": "0.3.1"
+            }
+        },
+        "ajv-keywords": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.1.0.tgz",
+            "integrity": "sha1-rCsnk5xUPpXSwG5/f1wnvkqlQ74=",
+            "dev": true
+        },
+        "ammo": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/ammo/-/ammo-3.0.0.tgz",
+            "integrity": "sha512-6yoz9MXYV9sgCHrwprHWPxBaJ9/roQRfXzS//4JCNgKfPYcghFNwJQKBt6vWOoSGGRHsP6qsLJ+xtKStKJWdLQ==",
+            "dev": true,
+            "requires": {
+                "boom": "6.0.0",
+                "hoek": "5.0.3"
+            },
+            "dependencies": {
+                "boom": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/boom/-/boom-6.0.0.tgz",
+                    "integrity": "sha512-LYLa8BmiiOWjvxTMVh73lcZzd2E5yczrKvxAny1UuzO2tkarLrw4tdp3rdfmus3+YfKcZP0vRSM3Obh+fGK6eA==",
+                    "dev": true,
+                    "requires": {
+                        "hoek": "5.0.3"
+                    }
+                }
+            }
+        },
+        "ansi-escapes": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.0.0.tgz",
+            "integrity": "sha512-O/klc27mWNUigtv0F8NJWbLF00OcegQalkqKURWdosW08YZKi4m6CnSUSvIZG1otNJbTWhN01Hhz389DW7mvDQ==",
+            "dev": true
+        },
+        "ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "dev": true
+        },
+        "ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "dev": true,
+            "requires": {
+                "color-convert": "1.9.1"
+            }
+        },
+        "argparse": {
+            "version": "1.0.10",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+            "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+            "dev": true,
+            "requires": {
+                "sprintf-js": "1.0.3"
+            }
+        },
+        "array-union": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+            "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+            "dev": true,
+            "requires": {
+                "array-uniq": "1.0.3"
+            }
+        },
+        "array-uniq": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+            "dev": true
+        },
+        "arrify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+            "dev": true
+        },
+        "async-limiter": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+            "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
+        },
+        "b64": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/b64/-/b64-4.0.0.tgz",
+            "integrity": "sha512-EhmUQodKB0sdzPPrbIWbGqA5cQeTWxYrAgNeeT1rLZWtD3tbNTnphz8J4vkXI3cPgBNlXBjzEbzDzq0Nwi4f9A==",
+            "dev": true
+        },
+        "babel-code-frame": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
+            "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+            "dev": true,
+            "requires": {
+                "chalk": "1.1.3",
+                "esutils": "2.0.2",
+                "js-tokens": "3.0.2"
+            },
+            "dependencies": {
+                "ansi-styles": {
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                    "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+                    "dev": true
+                },
+                "chalk": {
+                    "version": "1.1.3",
+                    "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                    "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-styles": "2.2.1",
+                        "escape-string-regexp": "1.0.5",
+                        "has-ansi": "2.0.0",
+                        "strip-ansi": "3.0.1",
+                        "supports-color": "2.0.0"
+                    }
+                },
+                "strip-ansi": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                    "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                    "dev": true,
+                    "requires": {
+                        "ansi-regex": "2.1.1"
+                    }
+                },
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
+        "babel-eslint": {
+            "version": "8.0.3",
+            "resolved": "https://registry.npmjs.org/babel-eslint/-/babel-eslint-8.0.3.tgz",
+            "integrity": "sha512-7D4iUpylEiKJPGbeSAlNddGcmA41PadgZ6UAb6JVyh003h3d0EbZusYFBR/+nBgqtaVJM2J2zUVa3N0hrpMH6g==",
+            "dev": true,
+            "requires": {
+                "@babel/code-frame": "7.0.0-beta.31",
+                "@babel/traverse": "7.0.0-beta.31",
+                "@babel/types": "7.0.0-beta.31",
+                "babylon": "7.0.0-beta.31"
+            }
+        },
+        "babel-runtime": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+            "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+            "requires": {
+                "core-js": "2.5.3",
+                "regenerator-runtime": "0.11.1"
+            }
+        },
+        "babylon": {
+            "version": "7.0.0-beta.31",
+            "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.31.tgz",
+            "integrity": "sha512-6lm2mV3S51yEnKmQQNnswoABL1U1H1KHoCCVwdwI3hvIv+W7ya4ki7Aw4o4KxtUHjNKkK5WpZb22rrMMOcJXJQ==",
+            "dev": true
+        },
+        "balanced-match": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+            "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+            "dev": true
+        },
+        "big-time": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/big-time/-/big-time-2.0.0.tgz",
+            "integrity": "sha512-OXsmBxlRLwUc65MLta2EOyMTLcjZQkxHkJ81lVPeyVqZag8zhUfKRYIbF3E/IW/LWR8kf8a1GlRYkBXKVGqJOw==",
+            "dev": true
+        },
+        "bignumber.js": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-4.1.0.tgz",
+            "integrity": "sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA=="
+        },
+        "boom": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/boom/-/boom-7.1.1.tgz",
+            "integrity": "sha512-qwEARHTliqgEQiVkzKkkbLt3q0vRPIW60VRZ8zRnbjsm7INkPe9NxfAYDDYLZOdhxyUHa1gIe639Cx7t6RH/4A==",
+            "requires": {
+                "hoek": "5.0.3"
+            }
+        },
+        "bounce": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/bounce/-/bounce-1.2.0.tgz",
+            "integrity": "sha512-8syCGe8B2/WC53118/F/tFy5aW00j+eaGPXmAUP7iBhxc+EBZZxS1vKelWyBCH6IqojgS2t1gF0glH30qAJKEw==",
+            "dev": true,
+            "requires": {
+                "boom": "7.1.1",
+                "hoek": "5.0.3"
+            }
+        },
+        "brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "requires": {
+                "balanced-match": "1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "builtin-modules": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+            "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8=",
+            "dev": true
+        },
+        "call": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/call/-/call-5.0.1.tgz",
+            "integrity": "sha512-ollfFPSshiuYLp7AsrmpkQJ/PxCi6AzV81rCjBwWhyF2QGyUY/vPDMzoh4aUcWyucheRglG2LaS5qkIEfLRh6A==",
+            "dev": true,
+            "requires": {
+                "boom": "7.1.1",
+                "hoek": "5.0.3"
+            }
+        },
+        "caller-path": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+            "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+            "dev": true,
+            "requires": {
+                "callsites": "0.2.0"
+            }
+        },
+        "callsites": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+            "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+            "dev": true
+        },
+        "catbox": {
+            "version": "10.0.2",
+            "resolved": "https://registry.npmjs.org/catbox/-/catbox-10.0.2.tgz",
+            "integrity": "sha512-cTQTQeKMhWHU0lX8CADE3g1koGJu+AlcWFzAjMX/8P+XbkScGYw3tJsQpe2Oh8q68vOQbOLacz9k+6V/F3Z9DA==",
+            "dev": true,
+            "requires": {
+                "boom": "7.1.1",
+                "bounce": "1.2.0",
+                "hoek": "5.0.3",
+                "joi": "13.1.2"
+            }
+        },
+        "catbox-memory": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-3.1.1.tgz",
+            "integrity": "sha512-fl6TI/uneeUb9NGClKWZWkpCZQrkPmuVz/Jaqqb15vqW6KGfJ/vMP/ZMp8VgAkyTrrRvFHbFcS67sbU7EkvbhQ==",
+            "dev": true,
+            "requires": {
+                "big-time": "2.0.0",
+                "boom": "7.1.1",
+                "hoek": "5.0.3"
+            }
+        },
+        "cbor": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/cbor/-/cbor-3.0.3.tgz",
+            "integrity": "sha512-+UY2FhD8w4GCp8QzP2a3eW0NRTFh2BaXn6t/sVYtGzKJAl0LL8nwma7qzIwmojq7jMF94X5DVfBUeIj8BBHBqA==",
+            "requires": {
+                "bignumber.js": "4.1.0",
+                "commander": "2.15.0",
+                "json-text-sequence": "0.1.1",
+                "nofilter": "0.0.3"
+            }
+        },
+        "cbor-js": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/cbor-js/-/cbor-js-0.1.0.tgz",
+            "integrity": "sha1-yAzmEg84fo+qdDcN/aIdlluPx/k="
+        },
+        "chalk": {
+            "version": "2.3.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.2.tgz",
+            "integrity": "sha512-ZM4j2/ld/YZDc3Ma8PgN7gyAk+kHMMMyzLNryCPGhWrsfAuDVeuid5bpRFTDgMH9JBK2lA4dyyAkkZYF/WcqDQ==",
+            "dev": true,
+            "requires": {
+                "ansi-styles": "3.2.1",
+                "escape-string-regexp": "1.0.5",
+                "supports-color": "5.3.0"
+            }
+        },
+        "chardet": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
+            "integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
+            "dev": true
+        },
+        "circular-json": {
+            "version": "0.3.3",
+            "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+            "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
+            "dev": true
+        },
+        "cli-cursor": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+            "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+            "dev": true,
+            "requires": {
+                "restore-cursor": "2.0.0"
+            }
+        },
+        "cli-width": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+            "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+            "dev": true
+        },
+        "co": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+            "dev": true
+        },
+        "color-convert": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
+            "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+            "dev": true,
+            "requires": {
+                "color-name": "1.1.3"
+            }
+        },
+        "color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+            "dev": true
+        },
+        "commander": {
+            "version": "2.15.0",
+            "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.0.tgz",
+            "integrity": "sha512-7B1ilBwtYSbetCgTY1NJFg+gVpestg0fdA1MhC1Vs4ssyfSXnCAjFr+QcQM9/RedXC0EaUx1sG8Smgw2VfgKEg=="
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "concat-stream": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.1.tgz",
+            "integrity": "sha512-gslSSJx03QKa59cIKqeJO9HQ/WZMotvYJCuaUULrLpjj8oG40kV2Z+gz82pVxlTkOADi4PJxQPPfhl1ELYrrXw==",
+            "dev": true,
+            "requires": {
+                "inherits": "2.0.3",
+                "readable-stream": "2.3.5",
+                "typedarray": "0.0.6"
+            }
+        },
+        "contains-path": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+            "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+            "dev": true
+        },
+        "content": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/content/-/content-4.0.4.tgz",
+            "integrity": "sha512-h0r6/VHlhrLVFrTj612v5EPwqyMs3L79Uf4vEw0zFmywodU8TveiIuINp0//3/GRnAWrQbgSnazSosNkyAeVNA==",
+            "dev": true,
+            "requires": {
+                "boom": "7.1.1"
+            }
+        },
+        "core-js": {
+            "version": "2.5.3",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+            "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4="
+        },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
+        },
+        "cross-spawn": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+            "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+            "dev": true,
+            "requires": {
+                "lru-cache": "4.1.2",
+                "shebang-command": "1.2.0",
+                "which": "1.3.0"
+            }
+        },
+        "cryptiles": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-4.1.1.tgz",
+            "integrity": "sha512-YuQUPbcOmaZsdvxJZ25DCA1W+lLIRoPJKBDKin+St1RCYEERSfoe1d25B1MvWNHN3e8SpFSVsqYvEUjp8J9H2w==",
+            "dev": true,
+            "requires": {
+                "boom": "7.1.1"
+            }
+        },
+        "debug": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+            "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+            "dev": true,
+            "requires": {
+                "ms": "2.0.0"
+            }
+        },
+        "deep-is": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+            "dev": true
+        },
+        "del": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+            "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+            "dev": true,
+            "requires": {
+                "globby": "5.0.0",
+                "is-path-cwd": "1.0.0",
+                "is-path-in-cwd": "1.0.0",
+                "object-assign": "4.1.1",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1",
+                "rimraf": "2.6.2"
+            }
+        },
+        "delimit-stream": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/delimit-stream/-/delimit-stream-0.1.0.tgz",
+            "integrity": "sha1-m4MZR3wOX4rrPONXrjBfwl6hzSs="
+        },
+        "doctrine": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
+            "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
+            "dev": true,
+            "requires": {
+                "esutils": "2.0.2"
+            }
+        },
+        "encodr": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/encodr/-/encodr-1.0.6.tgz",
+            "integrity": "sha512-91aqjFBg40zhLd6PKpR5Nk9HNnP0+FivAwJ89h4kv9N72/zj7FULTxHrJA14L6HLEVgxAMhk+HJ7rXox/QzL5A==",
+            "requires": {
+                "babel-runtime": "6.26.0",
+                "cbor": "3.0.3",
+                "cbor-js": "0.1.0",
+                "msgpack-lite": "0.1.26",
+                "utf8": "3.0.0"
+            }
+        },
+        "error-ex": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
+            "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+            "dev": true,
+            "requires": {
+                "is-arrayish": "0.2.1"
+            }
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
+        "eslint": {
+            "version": "4.12.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.12.1.tgz",
+            "integrity": "sha512-28hOYej+NZ/R5H1yMvyKa1+bPlu+fnsIAQffK6hxXgvmXnImos2bA5XfCn5dYv2k2mrKj+/U/Z4L5ICWxC7TQw==",
+            "dev": true,
+            "requires": {
+                "ajv": "5.5.2",
+                "babel-code-frame": "6.26.0",
+                "chalk": "2.3.2",
+                "concat-stream": "1.6.1",
+                "cross-spawn": "5.1.0",
+                "debug": "3.1.0",
+                "doctrine": "2.1.0",
+                "eslint-scope": "3.7.1",
+                "espree": "3.5.4",
+                "esquery": "1.0.0",
+                "estraverse": "4.2.0",
+                "esutils": "2.0.2",
+                "file-entry-cache": "2.0.0",
+                "functional-red-black-tree": "1.0.1",
+                "glob": "7.1.2",
+                "globals": "11.3.0",
+                "ignore": "3.3.7",
+                "imurmurhash": "0.1.4",
+                "inquirer": "3.3.0",
+                "is-resolvable": "1.1.0",
+                "js-yaml": "3.11.0",
+                "json-stable-stringify-without-jsonify": "1.0.1",
+                "levn": "0.3.0",
+                "lodash": "4.17.5",
+                "minimatch": "3.0.4",
+                "mkdirp": "0.5.1",
+                "natural-compare": "1.4.0",
+                "optionator": "0.8.2",
+                "path-is-inside": "1.0.2",
+                "pluralize": "7.0.0",
+                "progress": "2.0.0",
+                "require-uncached": "1.0.3",
+                "semver": "5.5.0",
+                "strip-ansi": "4.0.0",
+                "strip-json-comments": "2.0.1",
+                "table": "4.0.3",
+                "text-table": "0.2.0"
+            },
+            "dependencies": {
+                "globals": {
+                    "version": "11.3.0",
+                    "resolved": "https://registry.npmjs.org/globals/-/globals-11.3.0.tgz",
+                    "integrity": "sha512-kkpcKNlmQan9Z5ZmgqKH/SMbSmjxQ7QjyNqfXVc8VJcoBV2UEg+sxQD15GQofGRh2hfpwUb70VC31DR7Rq5Hdw==",
+                    "dev": true
+                }
+            }
+        },
+        "eslint-config-standard": {
+            "version": "10.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-config-standard/-/eslint-config-standard-10.2.1.tgz",
+            "integrity": "sha1-wGHk0GbzedwXzVYsZOgZtN1FRZE=",
+            "dev": true
+        },
+        "eslint-import-resolver-node": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
+            "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
+            "dev": true,
+            "requires": {
+                "debug": "2.6.9",
+                "resolve": "1.5.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
+        "eslint-module-utils": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.1.1.tgz",
+            "integrity": "sha512-jDI/X5l/6D1rRD/3T43q8Qgbls2nq5km5KSqiwlyUbGo5+04fXhMKdCPhjwbqAa6HXWaMxj8Q4hQDIh7IadJQw==",
+            "dev": true,
+            "requires": {
+                "debug": "2.6.9",
+                "pkg-dir": "1.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                }
+            }
+        },
+        "eslint-plugin-import": {
+            "version": "2.8.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.8.0.tgz",
+            "integrity": "sha512-Rf7dfKJxZ16QuTgVv1OYNxkZcsu/hULFnC+e+w0Gzi6jMC3guQoWQgxYxc54IDRinlb6/0v5z/PxxIKmVctN+g==",
+            "dev": true,
+            "requires": {
+                "builtin-modules": "1.1.1",
+                "contains-path": "0.1.0",
+                "debug": "2.6.9",
+                "doctrine": "1.5.0",
+                "eslint-import-resolver-node": "0.3.2",
+                "eslint-module-utils": "2.1.1",
+                "has": "1.0.1",
+                "lodash.cond": "4.5.2",
+                "minimatch": "3.0.4",
+                "read-pkg-up": "2.0.0"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "2.6.9",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                    "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+                    "dev": true,
+                    "requires": {
+                        "ms": "2.0.0"
+                    }
+                },
+                "doctrine": {
+                    "version": "1.5.0",
+                    "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+                    "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+                    "dev": true,
+                    "requires": {
+                        "esutils": "2.0.2",
+                        "isarray": "1.0.0"
+                    }
+                }
+            }
+        },
+        "eslint-plugin-node": {
+            "version": "5.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-node/-/eslint-plugin-node-5.2.1.tgz",
+            "integrity": "sha512-xhPXrh0Vl/b7870uEbaumb2Q+LxaEcOQ3kS1jtIXanBAwpMre1l5q/l2l/hESYJGEFKuI78bp6Uw50hlpr7B+g==",
+            "dev": true,
+            "requires": {
+                "ignore": "3.3.7",
+                "minimatch": "3.0.4",
+                "resolve": "1.5.0",
+                "semver": "5.3.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "5.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+                    "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+                    "dev": true
+                }
+            }
+        },
+        "eslint-plugin-promise": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-promise/-/eslint-plugin-promise-3.6.0.tgz",
+            "integrity": "sha512-YQzM6TLTlApAr7Li8vWKR+K3WghjwKcYzY0d2roWap4SLK+kzuagJX/leTetIDWsFcTFnKNJXWupDCD6aZkP2Q==",
+            "dev": true
+        },
+        "eslint-plugin-standard": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-standard/-/eslint-plugin-standard-3.0.1.tgz",
+            "integrity": "sha1-NNDJFbRe3G8BA5PH7vOCOwhWXPI=",
+            "dev": true
+        },
+        "eslint-scope": {
+            "version": "3.7.1",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
+            "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
+            "dev": true,
+            "requires": {
+                "esrecurse": "4.2.1",
+                "estraverse": "4.2.0"
+            }
+        },
+        "espree": {
+            "version": "3.5.4",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.4.tgz",
+            "integrity": "sha512-yAcIQxtmMiB/jL32dzEp2enBeidsB7xWPLNiw3IIkpVds1P+h7qF9YwJq1yUNzp2OKXgAprs4F61ih66UsoD1A==",
+            "dev": true,
+            "requires": {
+                "acorn": "5.5.3",
+                "acorn-jsx": "3.0.1"
+            }
+        },
+        "esprima": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+            "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+            "dev": true
+        },
+        "esquery": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+            "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+            "dev": true,
+            "requires": {
+                "estraverse": "4.2.0"
+            }
+        },
+        "esrecurse": {
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+            "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+            "dev": true,
+            "requires": {
+                "estraverse": "4.2.0"
+            }
+        },
+        "estraverse": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+            "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+            "dev": true
+        },
+        "esutils": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+            "dev": true
+        },
+        "event-lite": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/event-lite/-/event-lite-0.1.1.tgz",
+            "integrity": "sha1-R88IqNN9C2lM23s7F7UfqsZXYIY="
+        },
+        "eventemitter3": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.0.1.tgz",
+            "integrity": "sha512-QOCPu979MMWX9XNlfRZoin+Wm+bK1SP7vv3NGUniYwuSJK/+cPA10blMaeRgzg31RvoSFk6FsCDVa4vNryBTGA=="
+        },
+        "external-editor": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
+            "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
+            "dev": true,
+            "requires": {
+                "chardet": "0.4.2",
+                "iconv-lite": "0.4.19",
+                "tmp": "0.0.33"
+            }
+        },
+        "fast-deep-equal": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+            "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
+            "dev": true
+        },
+        "fast-json-stable-stringify": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+            "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+            "dev": true
+        },
+        "fast-levenshtein": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+            "dev": true
+        },
+        "figures": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+            "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+            "dev": true,
+            "requires": {
+                "escape-string-regexp": "1.0.5"
+            }
+        },
+        "file-entry-cache": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+            "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+            "dev": true,
+            "requires": {
+                "flat-cache": "1.3.0",
+                "object-assign": "4.1.1"
+            }
+        },
+        "find-up": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+            "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+            "dev": true,
+            "requires": {
+                "path-exists": "2.1.0",
+                "pinkie-promise": "2.0.1"
+            }
+        },
+        "flat-cache": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
+            "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
+            "dev": true,
+            "requires": {
+                "circular-json": "0.3.3",
+                "del": "2.2.2",
+                "graceful-fs": "4.1.11",
+                "write": "0.2.1"
+            }
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "function-bind": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
+            "dev": true
+        },
+        "functional-red-black-tree": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+            "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+            "dev": true
+        },
+        "glob": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+            "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
+            "dev": true,
+            "requires": {
+                "fs.realpath": "1.0.0",
+                "inflight": "1.0.6",
+                "inherits": "2.0.3",
+                "minimatch": "3.0.4",
+                "once": "1.4.0",
+                "path-is-absolute": "1.0.1"
+            }
+        },
+        "globals": {
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-10.4.0.tgz",
+            "integrity": "sha512-uNUtxIZpGyuaq+5BqGGQHsL4wUlJAXRqOm6g3Y48/CWNGTLONgBibI0lh6lGxjR2HljFYUfszb+mk4WkgMntsA==",
+            "dev": true
+        },
+        "globby": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+            "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+            "dev": true,
+            "requires": {
+                "array-union": "1.0.2",
+                "arrify": "1.0.1",
+                "glob": "7.1.2",
+                "object-assign": "4.1.1",
+                "pify": "2.3.0",
+                "pinkie-promise": "2.0.1"
+            }
+        },
+        "graceful-fs": {
+            "version": "4.1.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+            "dev": true
+        },
+        "hapi": {
+            "version": "17.2.3",
+            "resolved": "https://registry.npmjs.org/hapi/-/hapi-17.2.3.tgz",
+            "integrity": "sha512-e3Jm2xoZotUgsGAV/NTgg1EOXDeZFwbGr8ruUv9yH/DGyGl+NydEBOR7o28N2YbUs8WhBgi+TSVFL+2vtAe9xQ==",
+            "dev": true,
+            "requires": {
+                "accept": "3.0.2",
+                "ammo": "3.0.0",
+                "boom": "7.1.1",
+                "bounce": "1.2.0",
+                "call": "5.0.1",
+                "catbox": "10.0.2",
+                "catbox-memory": "3.1.1",
+                "heavy": "6.1.0",
+                "hoek": "5.0.3",
+                "joi": "13.1.2",
+                "mimos": "4.0.0",
+                "podium": "3.1.2",
+                "shot": "4.0.5",
+                "statehood": "6.0.5",
+                "subtext": "6.0.7",
+                "teamwork": "3.0.1",
+                "topo": "3.0.0"
+            }
+        },
+        "hapi-auth-basic": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/hapi-auth-basic/-/hapi-auth-basic-5.0.0.tgz",
+            "integrity": "sha1-BDiwAiXk97rM1/KeBLT8UDfAErA=",
+            "dev": true,
+            "requires": {
+                "boom": "7.1.1",
+                "hoek": "5.0.3"
+            }
+        },
+        "has": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
+            "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+            "dev": true,
+            "requires": {
+                "function-bind": "1.1.1"
+            }
+        },
+        "has-ansi": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "2.1.1"
+            }
+        },
+        "has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+            "dev": true
+        },
+        "heavy": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/heavy/-/heavy-6.1.0.tgz",
+            "integrity": "sha512-TKS9DC9NOTGulHQI31Lx+bmeWmNOstbJbGMiN3pX6bF+Zc2GKSpbbym4oasNnB6yPGkqJ9TQXXYDGohqNSJRxA==",
+            "dev": true,
+            "requires": {
+                "boom": "7.1.1",
+                "hoek": "5.0.3",
+                "joi": "13.1.2"
+            }
+        },
+        "hoek": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/hoek/-/hoek-5.0.3.tgz",
+            "integrity": "sha512-Bmr56pxML1c9kU+NS51SMFkiVQAb+9uFfXwyqR2tn4w2FPvmPt65eZ9aCcEfRXd9G74HkZnILC6p967pED4aiw=="
+        },
+        "hosted-git-info": {
+            "version": "2.6.0",
+            "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
+            "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
+            "dev": true
+        },
+        "iconv-lite": {
+            "version": "0.4.19",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+            "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+            "dev": true
+        },
+        "ieee754": {
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.8.tgz",
+            "integrity": "sha1-vjPUCsEO8ZJnAfbwii2G+/0a0+Q="
+        },
+        "ignore": {
+            "version": "3.3.7",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.7.tgz",
+            "integrity": "sha512-YGG3ejvBNHRqu0559EOxxNFihD0AjpvHlC/pdGKd3X3ofe+CoJkYazwNJYTNebqpPKN+VVQbh4ZFn1DivMNuHA==",
+            "dev": true
+        },
+        "imurmurhash": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+            "dev": true
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true,
+            "requires": {
+                "once": "1.4.0",
+                "wrappy": "1.0.2"
+            }
+        },
+        "inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+            "dev": true
+        },
+        "inquirer": {
+            "version": "3.3.0",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
+            "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
+            "dev": true,
+            "requires": {
+                "ansi-escapes": "3.0.0",
+                "chalk": "2.3.2",
+                "cli-cursor": "2.1.0",
+                "cli-width": "2.2.0",
+                "external-editor": "2.1.0",
+                "figures": "2.0.0",
+                "lodash": "4.17.5",
+                "mute-stream": "0.0.7",
+                "run-async": "2.3.0",
+                "rx-lite": "4.0.8",
+                "rx-lite-aggregates": "4.0.8",
+                "string-width": "2.1.1",
+                "strip-ansi": "4.0.0",
+                "through": "2.3.8"
+            }
+        },
+        "int64-buffer": {
+            "version": "0.1.10",
+            "resolved": "https://registry.npmjs.org/int64-buffer/-/int64-buffer-0.1.10.tgz",
+            "integrity": "sha1-J3siiofZWtd30HwTgyAiQGpHNCM="
+        },
+        "invariant": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+            "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+            "dev": true,
+            "requires": {
+                "loose-envify": "1.3.1"
+            }
+        },
+        "iron": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/iron/-/iron-5.0.4.tgz",
+            "integrity": "sha512-7iQ5/xFMIYaNt9g2oiNiWdhrOTdRUMFaWENUd0KghxwPUhrIH8DUY8FEyLNTTzf75jaII+jMexLdY/2HfV61RQ==",
+            "dev": true,
+            "requires": {
+                "boom": "7.1.1",
+                "cryptiles": "4.1.1",
+                "hoek": "5.0.3"
+            }
+        },
+        "is-arrayish": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+            "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
+            "dev": true
+        },
+        "is-builtin-module": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+            "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+            "dev": true,
+            "requires": {
+                "builtin-modules": "1.1.1"
+            }
+        },
+        "is-fullwidth-code-point": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+            "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+            "dev": true
+        },
+        "is-path-cwd": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+            "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+            "dev": true
+        },
+        "is-path-in-cwd": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+            "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+            "dev": true,
+            "requires": {
+                "is-path-inside": "1.0.1"
+            }
+        },
+        "is-path-inside": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
+            "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
+            "dev": true,
+            "requires": {
+                "path-is-inside": "1.0.2"
+            }
+        },
+        "is-promise": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+            "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+            "dev": true
+        },
+        "is-resolvable": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.1.0.tgz",
+            "integrity": "sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==",
+            "dev": true
+        },
+        "isarray": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+            "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+        },
+        "isemail": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/isemail/-/isemail-3.1.1.tgz",
+            "integrity": "sha512-mVjAjvdPkpwXW61agT2E9AkGoegZO7SdJGCezWwxnETL58f5KwJ4vSVAMBUL5idL6rTlYAIGkX3n4suiviMLNw==",
+            "dev": true,
+            "requires": {
+                "punycode": "2.1.0"
+            }
+        },
+        "isexe": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+            "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+            "dev": true
+        },
+        "joi": {
+            "version": "13.1.2",
+            "resolved": "https://registry.npmjs.org/joi/-/joi-13.1.2.tgz",
+            "integrity": "sha512-bZZSQYW5lPXenOfENvgCBPb9+H6E6MeNWcMtikI04fKphj5tvFL9TOb+H2apJzbCrRw/jebjTH8z6IHLpBytGg==",
+            "dev": true,
+            "requires": {
+                "hoek": "5.0.3",
+                "isemail": "3.1.1",
+                "topo": "3.0.0"
+            }
+        },
+        "js-tokens": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
+            "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+            "dev": true
+        },
+        "js-yaml": {
+            "version": "3.11.0",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.11.0.tgz",
+            "integrity": "sha512-saJstZWv7oNeOyBh3+Dx1qWzhW0+e6/8eDzo7p5rDFqxntSztloLtuKu+Ejhtq82jsilwOIZYsCz+lIjthg1Hw==",
+            "dev": true,
+            "requires": {
+                "argparse": "1.0.10",
+                "esprima": "4.0.0"
+            }
+        },
+        "json-schema-traverse": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+            "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A=",
+            "dev": true
+        },
+        "json-stable-stringify-without-jsonify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+            "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+            "dev": true
+        },
+        "json-text-sequence": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/json-text-sequence/-/json-text-sequence-0.1.1.tgz",
+            "integrity": "sha1-py8hfcSvxGKf/1/rME3BvVGi89I=",
+            "requires": {
+                "delimit-stream": "0.1.0"
+            }
+        },
+        "levn": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+            "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2"
+            }
+        },
+        "load-json-file": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+            "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.1.11",
+                "parse-json": "2.2.0",
+                "pify": "2.3.0",
+                "strip-bom": "3.0.0"
+            }
+        },
+        "locate-path": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+            "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+            "dev": true,
+            "requires": {
+                "p-locate": "2.0.0",
+                "path-exists": "3.0.0"
+            },
+            "dependencies": {
+                "path-exists": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+                    "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+                    "dev": true
+                }
+            }
+        },
+        "lodash": {
+            "version": "4.17.5",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
+            "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+            "dev": true
+        },
+        "lodash.cond": {
+            "version": "4.5.2",
+            "resolved": "https://registry.npmjs.org/lodash.cond/-/lodash.cond-4.5.2.tgz",
+            "integrity": "sha1-9HGh2khr5g9quVXRcRVSPdHSVdU=",
+            "dev": true
+        },
+        "loose-envify": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
+            "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+            "dev": true,
+            "requires": {
+                "js-tokens": "3.0.2"
+            }
+        },
+        "lru-cache": {
+            "version": "4.1.2",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
+            "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+            "dev": true,
+            "requires": {
+                "pseudomap": "1.0.2",
+                "yallist": "2.1.2"
+            }
+        },
+        "mime-db": {
+            "version": "1.33.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+            "integrity": "sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==",
+            "dev": true
+        },
+        "mimic-fn": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+            "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+            "dev": true
+        },
+        "mimos": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mimos/-/mimos-4.0.0.tgz",
+            "integrity": "sha512-JvlvRLqGIlk+AYypWrbrDmhsM+6JVx/xBM5S3AMwTBz1trPCEoPN/swO2L4Wu653fL7oJdgk8DMQyG/Gq3JkZg==",
+            "dev": true,
+            "requires": {
+                "hoek": "5.0.3",
+                "mime-db": "1.33.0"
+            }
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true,
+            "requires": {
+                "brace-expansion": "1.1.11"
+            }
+        },
+        "minimist": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+            "dev": true
+        },
+        "mkdirp": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "dev": true,
+            "requires": {
+                "minimist": "0.0.8"
+            }
+        },
+        "ms": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+            "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+            "dev": true
+        },
+        "msgpack-lite": {
+            "version": "0.1.26",
+            "resolved": "https://registry.npmjs.org/msgpack-lite/-/msgpack-lite-0.1.26.tgz",
+            "integrity": "sha1-3TxQsm8FnyXn7e42REGDWOKprYk=",
+            "requires": {
+                "event-lite": "0.1.1",
+                "ieee754": "1.1.8",
+                "int64-buffer": "0.1.10",
+                "isarray": "1.0.0"
+            }
+        },
+        "mute-stream": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+            "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+            "dev": true
+        },
+        "natural-compare": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+            "dev": true
+        },
+        "nigel": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/nigel/-/nigel-3.0.0.tgz",
+            "integrity": "sha512-ufFVFCe1zS/pfIQzQNa5uJxB8v8IcVTUn1zyPvQwb4CQGRxxBfdQPSXpEnI6ZzIwbV5L+GuAoRhYgcVSvTO7fA==",
+            "dev": true,
+            "requires": {
+                "hoek": "5.0.3",
+                "vise": "3.0.0"
+            }
+        },
+        "nofilter": {
+            "version": "0.0.3",
+            "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-0.0.3.tgz",
+            "integrity": "sha1-JB40IHgXeoaTowQ+g/N1Z+J2QQw="
+        },
+        "normalize-package-data": {
+            "version": "2.4.0",
+            "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
+            "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
+            "dev": true,
+            "requires": {
+                "hosted-git-info": "2.6.0",
+                "is-builtin-module": "1.0.0",
+                "semver": "5.5.0",
+                "validate-npm-package-license": "3.0.3"
+            }
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "dev": true
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true,
+            "requires": {
+                "wrappy": "1.0.2"
+            }
+        },
+        "onetime": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+            "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+            "dev": true,
+            "requires": {
+                "mimic-fn": "1.2.0"
+            }
+        },
+        "optionator": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+            "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+            "dev": true,
+            "requires": {
+                "deep-is": "0.1.3",
+                "fast-levenshtein": "2.0.6",
+                "levn": "0.3.0",
+                "prelude-ls": "1.1.2",
+                "type-check": "0.3.2",
+                "wordwrap": "1.0.0"
+            }
+        },
+        "os-tmpdir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+            "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+            "dev": true
+        },
+        "p-limit": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
+            "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+            "dev": true,
+            "requires": {
+                "p-try": "1.0.0"
+            }
+        },
+        "p-locate": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+            "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+            "dev": true,
+            "requires": {
+                "p-limit": "1.2.0"
+            }
+        },
+        "p-try": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+            "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+            "dev": true
+        },
+        "parse-json": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+            "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+            "dev": true,
+            "requires": {
+                "error-ex": "1.3.1"
+            }
+        },
+        "path-exists": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+            "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+            "dev": true,
+            "requires": {
+                "pinkie-promise": "2.0.1"
+            }
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
+        "path-is-inside": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+            "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+            "dev": true
+        },
+        "path-parse": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+            "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+            "dev": true
+        },
+        "path-type": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+            "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+            "dev": true,
+            "requires": {
+                "pify": "2.3.0"
+            }
+        },
+        "pez": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/pez/-/pez-4.0.1.tgz",
+            "integrity": "sha512-0c/SoW5MY7lPdc5U1Q/ixyjLZbluGWJonHVmn4mKwSq7vgO9+a9WzoCopHubIwkot6Q+fevNVElaA+1M9SqHrA==",
+            "dev": true,
+            "requires": {
+                "b64": "4.0.0",
+                "boom": "7.1.1",
+                "content": "4.0.4",
+                "hoek": "5.0.3",
+                "nigel": "3.0.0"
+            }
+        },
+        "pify": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+            "dev": true
+        },
+        "pinkie": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+            "dev": true
+        },
+        "pinkie-promise": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+            "dev": true,
+            "requires": {
+                "pinkie": "2.0.4"
+            }
+        },
+        "pkg-dir": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
+            "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
+            "dev": true,
+            "requires": {
+                "find-up": "1.1.2"
+            }
+        },
+        "pluralize": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-7.0.0.tgz",
+            "integrity": "sha512-ARhBOdzS3e41FbkW/XWrTEtukqqLoK5+Z/4UeDaLuSW+39JPeFgs4gCGqsrJHVZX0fUrx//4OF0K1CUGwlIFow==",
+            "dev": true
+        },
+        "podium": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/podium/-/podium-3.1.2.tgz",
+            "integrity": "sha512-18VrjJAduIdPv7d9zWsfmKxTj3cQTYC5Pv5gtKxcWujYBpGbV+mhNSPYhlHW5xeWoazYyKfB9FEsPT12r5rY1A==",
+            "dev": true,
+            "requires": {
+                "hoek": "5.0.3",
+                "joi": "13.1.2"
+            }
+        },
+        "prelude-ls": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+            "dev": true
+        },
+        "process-nextick-args": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+            "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+            "dev": true
+        },
+        "progress": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.0.tgz",
+            "integrity": "sha1-ihvjZr+Pwj2yvSPxDG/pILQ4nR8=",
+            "dev": true
+        },
+        "pseudomap": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+            "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+            "dev": true
+        },
+        "punycode": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
+            "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+            "dev": true
+        },
+        "read": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+            "integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+            "dev": true,
+            "requires": {
+                "mute-stream": "0.0.7"
+            }
+        },
+        "read-pkg": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+            "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+            "dev": true,
+            "requires": {
+                "load-json-file": "2.0.0",
+                "normalize-package-data": "2.4.0",
+                "path-type": "2.0.0"
+            }
+        },
+        "read-pkg-up": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+            "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+            "dev": true,
+            "requires": {
+                "find-up": "2.1.0",
+                "read-pkg": "2.0.0"
+            },
+            "dependencies": {
+                "find-up": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+                    "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+                    "dev": true,
+                    "requires": {
+                        "locate-path": "2.0.0"
+                    }
+                }
+            }
+        },
+        "readable-stream": {
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.5.tgz",
+            "integrity": "sha512-tK0yDhrkygt/knjowCUiWP9YdV7c5R+8cR0r/kt9ZhBU906Fs6RpQJCEilamRJj1Nx2rWI6LkW9gKqjTkshhEw==",
+            "dev": true,
+            "requires": {
+                "core-util-is": "1.0.2",
+                "inherits": "2.0.3",
+                "isarray": "1.0.0",
+                "process-nextick-args": "2.0.0",
+                "safe-buffer": "5.1.1",
+                "string_decoder": "1.0.3",
+                "util-deprecate": "1.0.2"
+            }
+        },
+        "regenerator-runtime": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+            "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+        },
+        "require-uncached": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+            "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+            "dev": true,
+            "requires": {
+                "caller-path": "0.1.0",
+                "resolve-from": "1.0.1"
+            }
+        },
+        "resolve": {
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+            "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+            "dev": true,
+            "requires": {
+                "path-parse": "1.0.5"
+            }
+        },
+        "resolve-from": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+            "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+            "dev": true
+        },
+        "restore-cursor": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+            "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+            "dev": true,
+            "requires": {
+                "onetime": "2.0.1",
+                "signal-exit": "3.0.2"
+            }
+        },
+        "rimraf": {
+            "version": "2.6.2",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+            "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+            "dev": true,
+            "requires": {
+                "glob": "7.1.2"
+            }
+        },
+        "run-async": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+            "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+            "dev": true,
+            "requires": {
+                "is-promise": "2.1.0"
+            }
+        },
+        "rx-lite": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-4.0.8.tgz",
+            "integrity": "sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=",
+            "dev": true
+        },
+        "rx-lite-aggregates": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
+            "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
+            "dev": true,
+            "requires": {
+                "rx-lite": "4.0.8"
+            }
+        },
+        "safe-buffer": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+            "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
+        },
+        "semver": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+            "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA==",
+            "dev": true
+        },
+        "shebang-command": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+            "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+            "dev": true,
+            "requires": {
+                "shebang-regex": "1.0.0"
+            }
+        },
+        "shebang-regex": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+            "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+            "dev": true
+        },
+        "shot": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/shot/-/shot-4.0.5.tgz",
+            "integrity": "sha1-x+dFXRHWD2ts08Q+FaO0McF+VWY=",
+            "dev": true,
+            "requires": {
+                "hoek": "5.0.3",
+                "joi": "13.1.2"
+            }
+        },
+        "signal-exit": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+            "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+            "dev": true
+        },
+        "slice-ansi": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
+            "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
+            "dev": true,
+            "requires": {
+                "is-fullwidth-code-point": "2.0.0"
+            }
+        },
+        "spdx-correct": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.0.0.tgz",
+            "integrity": "sha512-N19o9z5cEyc8yQQPukRCZ9EUmb4HUpnrmaL/fxS2pBo2jbfcFRVuFZ/oFC+vZz0MNNk0h80iMn5/S6qGZOL5+g==",
+            "dev": true,
+            "requires": {
+                "spdx-expression-parse": "3.0.0",
+                "spdx-license-ids": "3.0.0"
+            }
+        },
+        "spdx-exceptions": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.1.0.tgz",
+            "integrity": "sha512-4K1NsmrlCU1JJgUrtgEeTVyfx8VaYea9J9LvARxhbHtVtohPs/gFGG5yy49beySjlIMhhXZ4QqujIZEfS4l6Cg==",
+            "dev": true
+        },
+        "spdx-expression-parse": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
+            "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+            "dev": true,
+            "requires": {
+                "spdx-exceptions": "2.1.0",
+                "spdx-license-ids": "3.0.0"
+            }
+        },
+        "spdx-license-ids": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.0.tgz",
+            "integrity": "sha512-2+EPwgbnmOIl8HjGBXXMd9NAu02vLjOO1nWw4kmeRDFyHn+M/ETfHxQUK0oXg8ctgVnl9t3rosNVsZ1jG61nDA==",
+            "dev": true
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
+        "statehood": {
+            "version": "6.0.5",
+            "resolved": "https://registry.npmjs.org/statehood/-/statehood-6.0.5.tgz",
+            "integrity": "sha512-HPa8qT5sGTBVn1Fc9czBYR1oo7gBaay3ysnb04cvcF80YrDIV7880KpjmMj54j7CrFuQFfgMRb44QCRxRmAdTg==",
+            "dev": true,
+            "requires": {
+                "boom": "7.1.1",
+                "bounce": "1.2.0",
+                "cryptiles": "4.1.1",
+                "hoek": "5.0.3",
+                "iron": "5.0.4",
+                "joi": "13.1.2"
+            }
+        },
+        "string-width": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+            "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+            "dev": true,
+            "requires": {
+                "is-fullwidth-code-point": "2.0.0",
+                "strip-ansi": "4.0.0"
+            }
+        },
+        "string_decoder": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+            "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+            "dev": true,
+            "requires": {
+                "safe-buffer": "5.1.1"
+            }
+        },
+        "strip-ansi": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+            "dev": true,
+            "requires": {
+                "ansi-regex": "3.0.0"
+            },
+            "dependencies": {
+                "ansi-regex": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "dev": true
+                }
+            }
+        },
+        "strip-bom": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+            "dev": true
+        },
+        "strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+            "dev": true
+        },
+        "subtext": {
+            "version": "6.0.7",
+            "resolved": "https://registry.npmjs.org/subtext/-/subtext-6.0.7.tgz",
+            "integrity": "sha512-IcJUvRjeR+NB437Iq+LORFNJW4L6Knqkj3oQrBrkdhIaS2VKJvx/9aYEq7vi+PEx5/OuehOL/40SkSZotLi/MA==",
+            "dev": true,
+            "requires": {
+                "boom": "7.1.1",
+                "content": "4.0.4",
+                "hoek": "5.0.3",
+                "pez": "4.0.1",
+                "wreck": "14.0.2"
+            }
+        },
+        "supports-color": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.3.0.tgz",
+            "integrity": "sha512-0aP01LLIskjKs3lq52EC0aGBAJhLq7B2Rd8HC/DR/PtNNpcLilNmHC12O+hu0usQpo7wtHNRqtrhBwtDb0+dNg==",
+            "dev": true,
+            "requires": {
+                "has-flag": "3.0.0"
+            }
+        },
+        "table": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/table/-/table-4.0.3.tgz",
+            "integrity": "sha512-S7rnFITmBH1EnyKcvxBh1LjYeQMmnZtCXSEbHcH6S0NoKit24ZuFO/T1vDcLdYsLQkM188PVVhQmzKIuThNkKg==",
+            "dev": true,
+            "requires": {
+                "ajv": "6.2.1",
+                "ajv-keywords": "3.1.0",
+                "chalk": "2.3.2",
+                "lodash": "4.17.5",
+                "slice-ansi": "1.0.0",
+                "string-width": "2.1.1"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "6.2.1",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.2.1.tgz",
+                    "integrity": "sha1-KKarxJOiq+D7TIUHrK7bQ/pVBnE=",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "1.1.0",
+                        "fast-json-stable-stringify": "2.0.0",
+                        "json-schema-traverse": "0.3.1"
+                    }
+                }
+            }
+        },
+        "teamwork": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/teamwork/-/teamwork-3.0.1.tgz",
+            "integrity": "sha512-hEkJIpDOfOYe9NYaLFk00zQbzZeKNCY8T2pRH3I13Y1mJwxaSQ6NEsjY5rCp+11ezCiZpWGoGFTbOuhg4qKevQ==",
+            "dev": true
+        },
+        "text-table": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+            "dev": true
+        },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
+        },
+        "tmp": {
+            "version": "0.0.33",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+            "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+            "dev": true,
+            "requires": {
+                "os-tmpdir": "1.0.2"
+            }
+        },
+        "to-fast-properties": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+            "integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
+            "dev": true
+        },
+        "topo": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/topo/-/topo-3.0.0.tgz",
+            "integrity": "sha512-Tlu1fGlR90iCdIPURqPiufqAlCZYzLjHYVVbcFWDMcX7+tK8hdZWAfsMrD/pBul9jqHHwFjNdf1WaxA9vTRRhw==",
+            "dev": true,
+            "requires": {
+                "hoek": "5.0.3"
+            }
+        },
+        "type-check": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+            "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+            "dev": true,
+            "requires": {
+                "prelude-ls": "1.1.2"
+            }
+        },
+        "typedarray": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+            "dev": true
+        },
+        "ultron": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
+            "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og=="
+        },
+        "urijs": {
+            "version": "1.19.1",
+            "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.1.tgz",
+            "integrity": "sha512-xVrGVi94ueCJNrBSTjWqjvtgvl3cyOTThp2zaMaFNGp3F542TR6sM3f2o8RqZl+AwteClSVmoCyt0ka4RjQOQg=="
+        },
+        "utf8": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+            "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ=="
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
+        },
+        "validate-npm-package-license": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.3.tgz",
+            "integrity": "sha512-63ZOUnL4SIXj4L0NixR3L1lcjO38crAbgrTpl28t8jjrfuiOBL5Iygm+60qPs/KsZGzPNg6Smnc/oY16QTjF0g==",
+            "dev": true,
+            "requires": {
+                "spdx-correct": "3.0.0",
+                "spdx-expression-parse": "3.0.0"
+            }
+        },
+        "vise": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/vise/-/vise-3.0.0.tgz",
+            "integrity": "sha512-kBFZLmiL1Vm3rHXphkhvvAcsjgeQXRrOFCbJb0I50YZZP4HGRNH+xGzK3matIMcpbsfr3I02u9odj4oCD0TWgA==",
+            "dev": true,
+            "requires": {
+                "hoek": "5.0.3"
+            }
+        },
+        "websocket-framed": {
+            "version": "1.0.12",
+            "resolved": "https://registry.npmjs.org/websocket-framed/-/websocket-framed-1.0.12.tgz",
+            "integrity": "sha512-g05ad1IP7m7q3EdMqAmYDTYg0LSZD8hTWvoHTgV/Fu3CE+WQEOAG6B0cT2DCiMhp32ycYzaMqD0QVVySeTqV6g==",
+            "requires": {
+                "encodr": "1.0.6",
+                "eventemitter3": "3.0.1"
+            }
+        },
+        "which": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
+            "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+            "dev": true,
+            "requires": {
+                "isexe": "2.0.0"
+            }
+        },
+        "wordwrap": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+            "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+            "dev": true
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        },
+        "wreck": {
+            "version": "14.0.2",
+            "resolved": "https://registry.npmjs.org/wreck/-/wreck-14.0.2.tgz",
+            "integrity": "sha512-QCm3omWNJUseqrSzwX2QZi1rBbmCfbFHJAXputLLyZ37VSiFnSYQB0ms/mPnSvrlIu7GVm89Y/gBNhSY26uVIQ==",
+            "dev": true,
+            "requires": {
+                "boom": "7.1.1",
+                "hoek": "5.0.3"
+            }
+        },
+        "write": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+            "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+            "dev": true,
+            "requires": {
+                "mkdirp": "0.5.1"
+            }
+        },
+        "ws": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-3.3.3.tgz",
+            "integrity": "sha512-nnWLa/NwZSt4KQJu51MYlCcSQ5g7INpOrOMt4XV8j4dqTXdmlUmSHQ8/oLC069ckre0fRsgfvsKwbTdtKLCDkA==",
+            "requires": {
+                "async-limiter": "1.0.0",
+                "safe-buffer": "5.1.1",
+                "ultron": "1.1.1"
+            }
+        },
+        "wscat": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/wscat/-/wscat-2.1.1.tgz",
+            "integrity": "sha512-dAkA5v8LGFF0ceCCa5KmZBzTOD2X942E4u5LN+f5kSapzP9AcuXHEqDc46yMP54KeTyu/dLEFLeyOPPr3uamAw==",
+            "dev": true,
+            "requires": {
+                "commander": "2.12.2",
+                "read": "1.0.7",
+                "ws": "3.3.3"
+            },
+            "dependencies": {
+                "commander": {
+                    "version": "2.12.2",
+                    "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+                    "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+                    "dev": true
+                }
+            }
+        },
+        "yallist": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+            "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+            "dev": true
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,43 +1,48 @@
 {
-    "name":        "hapi-plugin-websocket",
-    "version":     "1.2.18",
+    "name": "hapi-plugin-websocket",
+    "version": "2.0.0",
     "description": "HAPI plugin for seamless WebSocket integration",
-    "keywords":    [ "hapi", "plugin", "websocket" ],
-    "main":        "./hapi-plugin-websocket.js",
-    "license":     "MIT",
+    "keywords": [
+        "hapi",
+        "plugin",
+        "websocket"
+    ],
+    "main": "./hapi-plugin-websocket.js",
+    "license": "MIT",
     "repository": {
         "type": "git",
-        "url":  "https://github.com/rse/hapi-plugin-websocket.git"
+        "url": "https://github.com/rse/hapi-plugin-websocket.git"
     },
     "author": {
-        "name":  "Ralf S. Engelschall",
+        "name": "Ralf S. Engelschall",
         "email": "rse@engelschall.com",
-        "url":   "http://engelschall.com"
+        "url": "http://engelschall.com"
     },
     "homepage": "https://github.com/rse/hapi-plugin-websocket",
-    "bugs":     "https://github.com/rse/hapi-plugin-websocket/issues",
+    "bugs": "https://github.com/rse/hapi-plugin-websocket/issues",
     "devDependencies": {
-        "hapi":                    "~16.6.2",
-        "hapi-auth-basic":         "~4.2.0",
-        "babel-eslint":            "~8.0.3",
-        "eslint":                  "~4.12.1",
-        "eslint-config-standard":  "~10.2.1",
-        "eslint-plugin-standard":  "~3.0.1",
-        "eslint-plugin-promise":   "~3.6.0",
-        "eslint-plugin-import":    "~2.8.0",
-        "eslint-plugin-node":      "~5.2.1"
+        "babel-eslint": "~8.0.3",
+        "eslint": "~4.12.1",
+        "eslint-config-standard": "~10.2.1",
+        "eslint-plugin-import": "~2.8.0",
+        "eslint-plugin-node": "~5.2.1",
+        "eslint-plugin-promise": "~3.6.0",
+        "eslint-plugin-standard": "~3.0.1",
+        "hapi": "~17.2.0",
+        "hapi-auth-basic": "~5.0.0",
+        "wscat": "^2.1.1"
     },
     "dependencies": {
-        "urijs":                   "~1.19.0",
-        "hoek":                    "~5.0.2",
-        "boom":                    "~7.1.1",
-        "ws":                      "~3.3.2",
-        "websocket-framed":        "~1.0.11"
+        "urijs": "~1.19.0",
+        "hoek": "~5.0.2",
+        "boom": "~7.1.1",
+        "ws": "~3.3.2",
+        "websocket-framed": "~1.0.11"
     },
     "engines": {
-        "node":                    ">=6.0.0"
+        "node": ">=6.0.0"
     },
     "scripts": {
-        "prepublishOnly":          "eslint --config eslint.yaml hapi-plugin-websocket.js sample-server.js"
+        "prepublishOnly": "eslint --config eslint.yaml hapi-plugin-websocket.js sample-server.js"
     }
 }

--- a/sample-server.js
+++ b/sample-server.js
@@ -141,28 +141,3 @@ async function runServer() {
     }
 }
 runServer();
-        config: {
-            plugins: {
-                websocket: {
-                    only:          true,
-                    autoping:      30 * 1000,
-                    frame:         true,
-                    frameEncoding: "json",
-                    frameRequest:  "REQUEST",
-                    frameResponse: "RESPONSE"
-                }
-            }
-        },
-        handler: (request, h) => {
-            return { at: "framed", seen: request.payload };
-        }
-    })
-
-    try {
-        await server.start();
-    }
-    catch (e){
-        console.log(e);
-    }
-}
-runServer();

--- a/sample-server.js
+++ b/sample-server.js
@@ -4,122 +4,165 @@ const HAPI          = require("hapi")
 const HAPIWebSocket = require("./hapi-plugin-websocket")
 const HAPIAuthBasic = require("hapi-auth-basic")
 
-let server = new HAPI.Server()
-server.connection({ address: "127.0.0.1", port: 12345 })
+async function runServer() {
+    const server = new HAPI.Server({ address: "127.0.0.1", port: 12345 });
 
-server.register(HAPIWebSocket)
-server.register(HAPIAuthBasic)
+    await server.register([
+        HAPIWebSocket, 
+        HAPIAuthBasic
+    ]);
 
-server.auth.strategy("basic", "basic", {
-    validateFunc: (request, username, password, callback) => {
-        if (username === "foo" && password === "bar")
-            callback(null, true, { username: username })
-        else
-            callback(Boom.unauthorized("invalid username/password"), false)
-    }
-})
+    server.auth.strategy('basic', 'basic', {
+        validate: async (request, username, password, h) => {
+            let isValid = false;
+            let credentials = null;
+            if (username === "foo" && password === "bar"){
+                isValid = true;
+                credentials = {id: username, name:username};
+            }
+            return {isValid, credentials};                
+        }
+    });
 
-/*  plain REST route  */
-server.route({
-    method: "POST", path: "/foo",
-    config: {
-        payload: { output: "data", parse: true, allow: "application/json" }
-    },
-    handler: (request, reply) => {
-        reply({ at: "foo", seen: request.payload })
-    }
-})
+    /*  plain REST route  */
+    server.route({
+        method: "POST", path: "/foo",
+        config: {
+            payload: { output: "data", parse: true, allow: "application/json" }
+        },
+        handler: (request, h) => {
+            return { at: "foo", seen: request.payload };
+        }
+    })
 
-/*  combined REST/WebSocket route  */
-server.route({
-    method: "POST", path: "/bar",
-    config: {
-        payload: { output: "data", parse: true, allow: "application/json" },
-        plugins: { websocket: true }
-    },
-    handler: (request, reply) => {
-        let { mode } = request.websocket()
-        reply({ at: "bar", mode: mode, seen: request.payload })
-    }
-})
+    /*  combined REST/WebSocket route  */
+    server.route({
+        method: "POST", path: "/bar",
+        config: {
+            payload: { output: "data", parse: true, allow: "application/json" },
+            plugins: { websocket: true }
+        },
+        handler: (request, h) => {
+            let { mode } = request.websocket()
+            return { at: "bar", mode: mode, seen: request.payload };
+        }
+    })
 
-/*  exclusive WebSocket route  */
-server.route({
-    method: "POST", path: "/baz",
-    config: {
-        plugins: { websocket: { only: true, autoping: 30 * 1000 } }
-    },
-    handler: (request, reply) => {
-        reply({ at: "baz", seen: request.payload })
-    }
-})
+    /*  exclusive WebSocket route  */
+    server.route({
+        method: "POST", path: "/baz",
+        config: {
+            plugins: { websocket: { only: true, autoping: 30 * 1000 } }
+        },
+        handler: (request, h) => {
+            return { at: "baz", seen: request.payload };
+        }
+    })
 
-/*  full-featured exclusive WebSocket route  */
-server.route({
-    method: "POST", path: "/quux",
-    config: {
-        payload: { output: "data", parse: true, allow: "application/json" },
-        auth: { mode: "required", strategy: "basic" },
-        plugins: {
-            websocket: {
-                only: true,
-                initially: true,
-                subprotocol: "quux/1.0",
-                connect: ({ ctx, ws }) => {
-                    ctx.to = setInterval(() => {
-                        ws.send(JSON.stringify({ cmd: "PING" }))
-                    }, 5000)
-                },
-                disconnect: ({ ctx }) => {
-                    if (ctx.to !== null) {
-                        clearTimeout(this.ctx)
-                        ctx.to = null
+    /*  full-featured exclusive WebSocket route  */
+    server.route({
+        method: "POST", path: "/quux",
+        config: {
+            response: {
+              emptyStatusCode: 204
+            },
+            payload: { output: "data", parse: true, allow: "application/json" },
+            auth: { mode: "required", strategy: "basic" },
+            plugins: {
+                websocket: {
+                    only: true,
+                    initially: true,
+                    subprotocol: "quux/1.0",
+                    connect: ({ ctx, ws }) => {
+                        // NOTE: This will crash if the client disconnects
+                        ctx.to = setInterval(() => {
+                            ws.send(JSON.stringify({ cmd: "PING" }))
+                        }, 5000)
+                    },
+                    disconnect: ({ ctx }) => {
+                        if (ctx.to !== null) {
+                            clearTimeout(this.ctx)
+                            ctx.to = null
+                        }
                     }
                 }
             }
-        }
-    },
-    handler: (request, reply) => {
-        let { initially, ws } = request.websocket()
-        if (initially) {
-            ws.send(JSON.stringify({ cmd: "HELLO", arg: request.auth.credentials.username }))
-            return reply().code(204)
-        }
-        if (typeof request.payload.cmd !== "string")
-            return reply(Boom.badRequest("invalid request"))
-        if (request.payload.cmd === "PING")
-            return reply({ result: "PONG" })
-        else if (request.payload.cmd === "AWAKE-ALL") {
-            var peers = request.websocket().peers
-            peers.forEach((peer) => {
-                peer.send(JSON.stringify({ cmd: "AWAKE" }))
-            })
-            return reply().code(204)
-        }
-        else
-            return reply(Boom.badRequest("unknown command"))
-    }
-})
-
-/*  exclusive framed WebSocket route  */
-server.route({
-    method: "POST", path: "/framed",
-    config: {
-        plugins: {
-            websocket: {
-                only:          true,
-                autoping:      30 * 1000,
-                frame:         true,
-                frameEncoding: "json",
-                frameRequest:  "REQUEST",
-                frameResponse: "RESPONSE"
+        },
+        handler: (request, h) => {
+            let { initially, ws } = request.websocket()
+            if (initially) {
+                ws.send(JSON.stringify({ cmd: "HELLO", arg: request.auth.credentials.username }))
+                return ""
+            }
+            if (typeof request.payload.cmd !== "string"){
+                return Boom.badRequest("invalid request");
+            }
+            if (request.payload.cmd === "PING"){
+                return { result: "PONG" }
+            }
+            else if (request.payload.cmd === "AWAKE-ALL") {
+                var peers = request.websocket().peers
+                peers.forEach((peer) => {
+                    peer.send(JSON.stringify({ cmd: "AWAKE" }))
+                })
+                return ""            
+            }
+            else{
+                return Boom.badRequest("unknown command");
             }
         }
-    },
-    handler: (request, reply) => {
-        reply({ at: "framed", seen: request.payload })
+    })
+
+    /*  exclusive framed WebSocket route  */
+    server.route({
+        method: "POST", path: "/framed",
+        config: {
+            plugins: {
+                websocket: {
+                    only:          true,
+                    autoping:      30 * 1000,
+                    frame:         true,
+                    frameEncoding: "json",
+                    frameRequest:  "REQUEST",
+                    frameResponse: "RESPONSE"
+                }
+            }
+        },
+        handler: (request, h) => {
+            return { at: "framed", seen: request.payload };
+        }
+    })
+
+    try {
+        await server.start();
     }
-})
+    catch (e){
+        console.log(e);
+    }
+}
+runServer();
+        config: {
+            plugins: {
+                websocket: {
+                    only:          true,
+                    autoping:      30 * 1000,
+                    frame:         true,
+                    frameEncoding: "json",
+                    frameRequest:  "REQUEST",
+                    frameResponse: "RESPONSE"
+                }
+            }
+        },
+        handler: (request, h) => {
+            return { at: "framed", seen: request.payload };
+        }
+    })
 
-server.start()
-
+    try {
+        await server.start();
+    }
+    catch (e){
+        console.log(e);
+    }
+}
+runServer();


### PR DESCRIPTION
Hapi 17.0.0 was a big rewrite and tossed out all its callbacks in favor of async/await.  I was looking to use hapi-plugin-websocket on a project and thought I'd see about bringing it in line with that approach.  It was pretty quick.  

In the PR, I've changed the version string to `2.0.0` to signify that these are breaking changes.  It looks like most Hapi plugins have been maintaining a release compatible with Hapi <17  and a 17+-compatible release.  

Take a look and see if it works for you.

Cheers,
Evan