### PR TITLE
Docs and comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ const WebSocket     = require("ws")
     await server.register(HAPIWebSocket)
     await server.register(HAPIAuthBasic)
 
-    /*  register Basic authentication stategy  */
+    /*  register Basic authentication strategy  */
     server.auth.strategy("basic", "basic", {
         validate: async (request, username, password, h) => {
             let isValid     = false

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ const WebSocket     = require("ws")
                 websocket: {
                     only: true,
                     initially: true,
-                    subprotocol: "quux/1.0",
+                    subprotocol: "quux.example.com",
                     connect: ({ ctx, ws }) => {
                         ctx.to = setInterval(() => {
                             if (ws.readyState === WebSocket.OPEN)
@@ -210,7 +210,7 @@ $ wscat --connect ws://127.0.0.1:12345/baz
 < {"at":"baz","seen":{"foo":7}}
 
 # access the full-featured exclusive WebSocket route via WebSockets
-$ wscat --subprotocol "quux/1.0" --auth foo:bar --connect ws://127.0.0.1:12345/quux
+$ wscat --subprotocol "quux.example.com" --auth foo:bar --connect ws://127.0.0.1:12345/quux
 < {"cmd":"HELLO",arg:"foo"}
 > {"cmd":"PING"}
 < {"result":"PONG"}
@@ -281,7 +281,7 @@ server.route({
             websocket: {
                 only: true,
                 autoping: 10 * 1000,
-                subprotocol: "foo/1.0",
+                subprotocol: "v1.foo.example.com",
                 initially: true,
                 connect: ({ ctx, wss, ws, req, peers }) => {
                     ...

--- a/hapi-plugin-websocket.js
+++ b/hapi-plugin-websocket.js
@@ -132,7 +132,7 @@ const register = async (server, pluginOptions) => {
         /*  establish a WebSocket server and attach it to the
             Node HTTP server underlying the HAPI server  */
         wss = new WS.Server({
-            /*  the underyling HTTP server  */
+            /*  the underlying HTTP server  */
             server: server.listener,
 
             /*  disable per-server client tracking, as we have to perform it per-route  */
@@ -238,7 +238,7 @@ const register = async (server, pluginOptions) => {
                 /*  any HTTP redirection, client error or server error response
                     leads to an immediate WebSocket connection drop  */
                 if (response.statusCode >= 300) {
-                    const annotation = `(HAPI handler reponded with HTTP status ${response.statusCode})`
+                    const annotation = `(HAPI handler responded with HTTP status ${response.statusCode})`
                     if (response.statusCode < 400)
                         ws.close(1002, `Protocol Error ${annotation}`)
                     else if (response.statusCode < 500)
@@ -292,7 +292,7 @@ const register = async (server, pluginOptions) => {
                 })
             }
             else {
-                /*  plain WebSocket communication (uncorrelated request/reponse)  */
+                /*  plain WebSocket communication (uncorrelated request/response)  */
                 ws.on("message", async (message) => {
                     /*  inject incoming WebSocket message as a simulated HTTP request  */
                     const response = await server.inject({

--- a/sample-server.js
+++ b/sample-server.js
@@ -13,7 +13,7 @@ const WebSocket     = require("ws")
     await server.register(HAPIWebSocket)
     await server.register(HAPIAuthBasic)
 
-    /*  register Basic authentication stategy  */
+    /*  register Basic authentication strategy  */
     server.auth.strategy("basic", "basic", {
         validate: async (request, username, password, h) => {
             let isValid     = false

--- a/sample-server.js
+++ b/sample-server.js
@@ -72,7 +72,7 @@ const WebSocket     = require("ws")
                 websocket: {
                     only: true,
                     initially: true,
-                    subprotocol: "quux/1.0",
+                    subprotocol: "quux.example.com",
                     connect: ({ ctx, ws }) => {
                         ctx.to = setInterval(() => {
                             if (ws.readyState === WebSocket.OPEN)


### PR DESCRIPTION
Fix spelling.

Change subprotocol names: Use domain names, as suggested in https://www.rfc-editor.org/rfc/rfc6455#section-1.9. As documented in https://www.rfc-editor.org/rfc/rfc6455#section-4.1, `/` isn't valid in a subprotocol name. (This restriction is enforced by the ws package; see https://github.com/websockets/ws/blob/8.5.0/lib/websocket.js#L34.)