### PR TITLE
Fix setting request info properties

### DIFF
--- a/hapi-plugin-websocket.js
+++ b/hapi-plugin-websocket.js
@@ -371,8 +371,16 @@ const register = async (server, pluginOptions) => {
     /*  make available to HAPI request the remote WebSocket information  */
     server.ext({ type: "onRequest", method: (request, h) => {
         if (isRequestWebSocketDriven(request)) {
-            request.info.remoteAddress = request.plugins.websocket.req.socket.remoteAddress
-            request.info.remotePort    = request.plugins.websocket.req.socket.remotePort
+            /*  RequestInfo's remoteAddress and remotePort use getters and are not
+                settable, so we have to replace them.  */
+            Object.defineProperties(request.info, {
+                remoteAddress: {
+                    value: request.plugins.websocket.req.socket.remoteAddress
+                },
+                remotePort: {
+                    value: request.plugins.websocket.req.socket.remotePort
+                }
+            });
         }
         return h.continue
     } })


### PR DESCRIPTION
remoteAddress and remotePort are implemented as property getters, so trying to set them causes errors in strict mode and does nothing in non-strict mode.  Instead, use `Object.defineProperties` to override them.

See https://github.com/hapijs/hapi/blob/v20.2.1/lib/request.js#L657