### PR TITLE
fix Podium import

### DIFF
--- a/hapi-plugin-websocket.d.ts
+++ b/hapi-plugin-websocket.d.ts
@@ -23,7 +23,7 @@
 */
 
 import { Plugin, Request, ReqRef, ReqRefDefaults } from "@hapi/hapi"
-import { Podium }                                  from "@hapi/podium"
+import Podium                                      from "@hapi/podium"
 import * as ws                                     from "ws"
 import * as http                                   from "node:http"
 


### PR DESCRIPTION
Hi! I'm having issues compiling my TypeScript project that uses hapi-plugin-websocket, and I was getting this error, (referring to the import I'm updating in this PR):

```
Error: node_modules/hapi-plugin-websocket/hapi-plugin-websocket.d.ts(26,10): error TS2616: 'Podium' can only be imported by using 'import Podium = require("@hapi/podium")' or a default import.
```

Not sure if there's something I should do on my side to fix this, but it does seem like using the default export resolves the issue.